### PR TITLE
Allow Interface with wildcard property name

### DIFF
--- a/packages/json/examples/interfaces.json
+++ b/packages/json/examples/interfaces.json
@@ -83,7 +83,7 @@
                 "name": "*",
                 "kind": "prop",
                 "type": "any",
-                "required": true,
+                "required": false,
                 "readOnly": false,
                 "description": ""
             }

--- a/packages/json/examples/interfaces.json
+++ b/packages/json/examples/interfaces.json
@@ -78,6 +78,14 @@
                 "readOnly": true,
                 "description": "",
                 "default": "true"
+            },
+            {
+                "name": "*",
+                "kind": "prop",
+                "type": "any",
+                "required": true,
+                "readOnly": false,
+                "description": ""
             }
         ]
     }

--- a/packages/json/examples/interfaces.ts
+++ b/packages/json/examples/interfaces.ts
@@ -41,6 +41,5 @@ export interface Movie extends Media, ParentInterface {
      */
     readonly isAvailable: boolean;
 
-    // The following syntax is not supported yet
-    // [key: string]: any;
+    [key: string]: any;
 }

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -92,7 +92,7 @@ export function serializeProp(prop: ts.PropertySignature, checker: ts.TypeChecke
         kind: 'prop',
         // JSDoc @type will override the true type
         type: jsDocTags.type || type,
-        required: prop.name && !prop.questionToken,
+        required: !prop.questionToken,
         readOnly: ts.getCombinedModifierFlags(prop) === ts.ModifierFlags.Readonly,
         description: getJsDocDescription(prop as any) || '',
         ...jsDocTags

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -88,7 +88,7 @@ export function serializeProp(prop: ts.PropertySignature, checker: ts.TypeChecke
     const type = prop.type ? checker.typeToString(checker.getTypeFromTypeNode(prop.type)) : '';
 
     return {
-        name: prop.name.getText(),
+        name: prop.name ? prop.name.getText() : '*',
         kind: 'prop',
         // JSDoc @type will override the true type
         type: jsDocTags.type || type,

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -92,7 +92,7 @@ export function serializeProp(prop: ts.PropertySignature, checker: ts.TypeChecke
         kind: 'prop',
         // JSDoc @type will override the true type
         type: jsDocTags.type || type,
-        required: !prop.questionToken,
+        required: prop.name && !prop.questionToken,
         readOnly: ts.getCombinedModifierFlags(prop) === ts.ModifierFlags.Readonly,
         description: getJsDocDescription(prop as any) || '',
         ...jsDocTags

--- a/packages/json/src/serialize.ts
+++ b/packages/json/src/serialize.ts
@@ -92,7 +92,7 @@ export function serializeProp(prop: ts.PropertySignature, checker: ts.TypeChecke
         kind: 'prop',
         // JSDoc @type will override the true type
         type: jsDocTags.type || type,
-        required: !prop.questionToken,
+        required: prop.name ? !prop.questionToken : false,
         readOnly: ts.getCombinedModifierFlags(prop) === ts.ModifierFlags.Readonly,
         description: getJsDocDescription(prop as any) || '',
         ...jsDocTags


### PR DESCRIPTION
Hello there, 
first of all,thank you for this amazing addon !

While setting it up on a project of mine, I notice that in case of having Interfaces with wildcards as property names:

`[key: string]: string | number | undefined | boolean;`

following happens:

`node.name.getText()` returns an error due to `node.name` being `undefined` (serialize.ts : serializeProp function)

This PR just checks against `node.name` value, and sets it to  `"*"`  in case of `undefined`